### PR TITLE
Update depreciated clone URL to a supported format

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 Quickly install with:
 
-    git clone git://github.com/msanders/snipmate.vim.git
+    git clone git@github.com:msanders/snipmate.vim.git
 	cd snipmate.vim
 	cp -R * ~/.vim


### PR DESCRIPTION
Documentation for this change: https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting